### PR TITLE
Improve SQLite Queries

### DIFF
--- a/OFMetadataToStash.ps1
+++ b/OFMetadataToStash.ps1
@@ -799,7 +799,7 @@ function Add-MetadataUsingOFDB{
              
             if (!(DatabaseHasAlreadyBeenImported)){
                 #Select all the media (except audio) and the text the performer associated to them, if available from the OFDB
-                $Query = "SELECT messages.text, medias.directory, medias.filename, medias.size, medias.created_at, medias.post_id, medias.media_type FROM medias INNER JOIN messages ON messages.post_id=medias.post_id UNION SELECT posts.text, medias.directory, medias.filename, medias.size, medias.created_at, medias.post_id, medias.media_type FROM medias INNER JOIN posts ON posts.post_id=medias.post_id WHERE medias.media_type <> 'Audios'"
+                $Query = "SELECT descr.text, medias.directory, medias.filename, medias.size, medias.created_at, medias.post_id, medias.media_type FROM medias INNER JOIN (SELECT messages.text, messages.post_id FROM messages UNION SELECT posts.text, posts.post_id FROM posts UNION SELECT stories.text, stories.post_id FROM stories) as descr ON descr.post_id=medias.post_id WHERE medias.size IS NOT NULL ORDER BY medias.post_id ASC"
                 $OF_DBpath = $currentdatabase.fullname 
                 $OFDBQueryResult = Invoke-SqliteQuery -Query $Query -DataSource $OF_DBpath
 

--- a/OFMetadataToStash.ps1
+++ b/OFMetadataToStash.ps1
@@ -286,7 +286,7 @@ function DatabaseHasAlreadyBeenImported{
             if([datetime]$metadataLastWriteTime -gt [datetime]$performerFromHistory.import_date){
                 $currenttimestamp = get-date -format o
                 try { 
-                    $historyQuery = 'UPDATE import_date SET import_date = "'+$currenttimestamp+'" WHERE history.performer = "'+$performername+'"'
+                    $historyQuery = 'UPDATE history SET import_date = "'+$currenttimestamp+'" WHERE history.performer = "'+$performername+'"'
                     Invoke-SqliteQuery -Query $historyQuery -DataSource $PathToHistoryFile    
                 }
                 catch{


### PR DESCRIPTION
* Include stories in the metadata query and remove size = null from the list (reduces useless queries).
* Consolidate SQL queries for video and image (each one was repeated 4 times) and move the boilerplate GQL-wrapper into a function.
* Fix the history update sqlite query, which referenced the field instead of the table (causing an sql-error)